### PR TITLE
Add in debug logging method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ var app = feathers()
 * `app.info()`
 * `app.warn()`
 * `app.error()`
+* `app.debug()`
 
 They have graceful fallback to the [core nodejs console methods](http://nodejs.org/api/stdio.html).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,15 @@ module.exports = function (logger) {
         }
       },
 
+      debug: function() {
+        if (this._logger && typeof this._logger.debug === 'function') {
+          this._logger.debug.apply(this._logger, arguments);
+        }
+        else {
+          console.error('DEBUG: ', arguments);
+        }
+      },
+
       setup: function () {
         return this._super.apply(this, arguments);
       }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -26,4 +26,8 @@ describe('Feathers logger', function () {
   it('initializes .error', function () {
     expect(typeof app.error).to.equal('function');
   });
+
+  it('initializes .debug', function () {
+    expect(typeof app.debug).to.equal('function');
+  });
 });


### PR DESCRIPTION
Added debug logging method. This is available with the default winston logger, and is part of the Syslog RFC for logging levels: https://tools.ietf.org/html/rfc5424